### PR TITLE
feat(wolfssl): remove CURVED25519_SMALL to enable full-radix X25519 (#37)

### DIFF
--- a/benchmark_microbench_sp_curve25519_20260430.txt
+++ b/benchmark_microbench_sp_curve25519_20260430.txt
@@ -1,0 +1,16 @@
+lwIP init starting...
+[ETH] HAL_ETH_Init OK, starting IT...
+[ETH] HAL_ETH_Start_IT done
+lwIP init done, waiting for DHCP...
+[LWIP] Link UP callback - starting DHCP
+IP Address: 192.168.0.241
+
+[MICRO] ===== DWT Microbenchmark: P256 vs X25519 =====
+[MICRO] CPU=168000000 Hz  DWT_res=5.95 ns  N_P256=500 N_X25519=20
+
+[MICRO] P256_KEYGEN            n=500  mean= 20558.2 us  stddev=  33.4 us  min=20538.8  max=20972.3
+[MICRO] P256_ECDH              n=500  mean= 12867.7 us  stddev=  16.4 us  min=12848.8  max=13049.2
+[MICRO] X25519_KEYGEN          n=20  mean=115344.6 us  stddev=  54.5 us  min=115317.6  max=115553.5
+[MICRO] X25519_ECDH            n=20  mean=115113.0 us  stddev=  76.3 us  min=115064.2  max=115297.6
+
+[MICRO] ===== Done =====

--- a/wolfSSL/wolfSSL.I-CUBE-wolfSSL_conf.h
+++ b/wolfSSL/wolfSSL.I-CUBE-wolfSSL_conf.h
@@ -657,8 +657,9 @@
     #define HAVE_CURVE25519
     #define HAVE_ED25519
 
-    /* Optionally use small math (less flash usage, but much slower) */
-    #define CURVED25519_SMALL
+    /* Omit CURVED25519_SMALL to activate fe_operations.c (full 25-bit radix).
+     * ~11x faster than fe_low_mem on Cortex-M4F; costs +37 KB Flash.
+     * Note: WOLFSSL_SP_CURVE25519 does not exist in wolfSSL 5.8.4. */
 #endif
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

- `CURVED25519_SMALL` 제거로 wolfSSL이 `fe_operations.c`(full 25-bit radix) 경로 활성화
- `fe_low_mem.c` 대비 X25519 keygen/ECDH **11× 개선** (1274ms → 115ms @ Cortex-M4F 168MHz -O0)
- FLASH: +37 KB (269KB → 306KB / 2MB 중 14.6%)
- **주의**: `WOLFSSL_SP_CURVE25519`는 wolfSSL 5.8.4 트리에 존재하지 않음 — 추가 매크로 불필요

## Before / After

| 연산 | Before (fe_low_mem) | After (fe_operations) | 개선 |
|------|--------------------|-----------------------|------|
| P256_KEYGEN | 20,548 µs | 20,558 µs | 동일 |
| P256_ECDH | 12,824 µs | 12,868 µs | 동일 |
| X25519_KEYGEN | **1,274,208 µs** | **115,345 µs** | **11×** |
| X25519_ECDH | **1,272,261 µs** | **115,113 µs** | **11×** |

비율: X25519/P256 keygen **62× → 5.6×**, ECDH **99× → 8.9×** (-O0 한계, Phase G에서 -O2 재측정 예정)

## 메커니즘

`CURVED25519_SMALL` → `settings.h:4025`에서 `CURVE25519_SMALL`/`ED25519_SMALL` 정의
→ `fe_low_mem.c` 활성 (느린 small-radix 경로)

제거 후 → `fe_operations.c` 가드(`#if !defined(CURVE25519_SMALL)`) 통과
→ full 25-bit radix C 구현 활성화

## 검증

- errors=0, 빌드 경고 없음
- 결과 파일: `benchmark_microbench_sp_curve25519_20260430.txt`
- 코드 리뷰: critic(ACCEPT-WITH-RESERVATIONS) + code-reviewer(CRITICAL 수정 완료 후 ACCEPT)

Closes #37