### PR TITLE
fix(wolfssl): enforce PQC verification for all hybrid cert types (#44)

### DIFF
--- a/Middlewares/Third_Party/wolfSSL_wolfSSL_wolfSSL/wolfssl/src/internal.c
+++ b/Middlewares/Third_Party/wolfSSL_wolfSSL_wolfSSL/wolfssl/src/internal.c
@@ -15573,8 +15573,8 @@ static int VerifyChameleonDeltaSignature(WOLFSSL        *ssl,
     if (ca == NULL)
         ca = GetCA(SSL_CM(ssl), issuerHash);
     if (ca == NULL) {
-        WOLFSSL_MSG("[Chameleon] PQ ICA signer not found, skipping delta verify");
-        return WC_NO_ERR_TRACE(NOT_COMPILED_IN); /* non-fatal */
+        WOLFSSL_MSG("[Chameleon] PQ ICA signer not found in CM");
+        return WC_NO_ERR_TRACE(ASN_NO_SIGNER_E);
     }
 
     /* ------------------------------------------------------------------ */
@@ -16162,7 +16162,10 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 vr = ParseCertRelative(&pqDC, CHAIN_CERT_TYPE,
                                                        VERIFY, SSL_CM(ssl),
                                                        NULL);
-                                (void)vr;
+                                if (vr != 0) {
+                                    FreeDecodedCert(&pqDC);
+                                    ERROR_OUT(vr, exit_ppc);
+                                }
                                 FreeDecodedCert(&pqDC);
                             }
                         } /* while (listSz) — PQ chain certs */
@@ -16182,6 +16185,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                    "(err=%d)\r\n",
                                    vr == 0 ? "OK" : "FAIL", vr);
                             FreeDecodedCert(&pqDC);
+                            if (vr != 0) {
+                                ERROR_OUT(vr, exit_ppc);
+                            }
                         }
                         g_cert_t_pq_ms = tls13_tick_ms() - _pq_t0;
                     }

--- a/Middlewares/Third_Party/wolfSSL_wolfSSL_wolfSSL/wolfssl/src/tls13.c
+++ b/Middlewares/Third_Party/wolfSSL_wolfSSL_wolfSSL/wolfssl/src/tls13.c
@@ -11309,8 +11309,8 @@ static int DoTls13PQCertificateVerify(WOLFSSL* ssl, byte* input,
 
 #if defined(HAVE_DILITHIUM)
     if (ssl->peerSapkiDer == NULL || ssl->peerSapkiLen <= 0) {
-        /* No ML-DSA pubkey available — accept without verification */
-        goto accept;
+        ret = SIG_VERIFY_E;
+        goto done;
     }
 
     /* Build the data-to-sign */
@@ -11341,7 +11341,6 @@ static int DoTls13PQCertificateVerify(WOLFSSL* ssl, byte* input,
     /* verification result recorded in ret */
     goto done;
 
-accept:
 #else
     (void)sig; (void)sigLen;
 #endif /* HAVE_DILITHIUM */


### PR DESCRIPTION
## 배경

하이브리드 인증서 타입 5종에 대한 전수 감사 결과, Dual·Catalyst·Chameleon 3종에서
PQC 검증이 사실상 무효화되는 버그 발견 (Issue #44).

## 변경 사항

### tls13.c — `DoTls13PQCertificateVerify`
- `peerSapkiDer == NULL`일 때 `goto accept`(무조건 성공) → `ret = SIG_VERIFY_E; goto done;`(거부)
- 미사용 `accept:` 레이블 제거
- **영향**: Catalyst, Chameleon, Dual, Related 공통 PQCertVerify 경로 전체

### internal.c — Dual PQ ICA 검증 (`ProcessPeerCerts`)
- `(void)vr` → ICA verify 실패 시 `ERROR_OUT(vr, exit_ppc)` 핸드셰이크 abort
- ICA가 CM에 없는 상태에서 leaf verify가 `ASN_NO_SIGNER_E(-188)`를 반환하는 근본 원인 수정

### internal.c — Dual PQ leaf 검증
- leaf `ParseCertRelative` 실패 결과가 printf에만 사용되고 핸드셰이크에 미반영되던 문제 수정
- `if (vr != 0) ERROR_OUT(vr, exit_ppc)` 추가

### internal.c — `VerifyChameleonDeltaSignature`
- PQ ICA signer가 CM에 없을 때 `NOT_COMPILED_IN`(non-fatal, 검증 스킵) → `ASN_NO_SIGNER_E`(fatal)
- 호출부(`internal.c:17808`)의 `dret != NOT_COMPILED_IN` 조건이 `args->fatal = 1`을 트리거하게 됨

## 검증

- Debug 빌드 성공 (errors=0, FLASH 353 KB / 2 MB)
- RAM 99.27% — 기존과 동일

Closes #44